### PR TITLE
Change unpack1 -> unpack in get_array_of methods

### DIFF
--- a/lib/fiddley/memory_pointer.rb
+++ b/lib/fiddley/memory_pointer.rb
@@ -53,7 +53,7 @@ module Fiddley
       end
 
       define_method("get_array_of_int#{bits}") do |offset, num|
-        @ptr[offset, bytes*num].unpack1(form + '*')
+        @ptr[offset, bytes*num].unpack(form + '*')
       end
 
       define_method("read_array_of_int#{bits}") do |num|
@@ -87,7 +87,7 @@ module Fiddley
       end
 
       define_method("get_array_of_uint#{bits}") do |offset, num|
-        @ptr[offset, bytes*num].unpack1(form2 + '*')
+        @ptr[offset, bytes*num].unpack(form2 + '*')
       end
 
       define_method("read_array_of_uint#{bits}") do |num|


### PR DESCRIPTION
Hi developers. 

Thank you for creating a useful library.
I'm trying to switch from ruby-ffi to fiddle.
[GR.rb](https://github.com/kojix2/GR.rb)
However, `read_array_from` methods in the memory pointer class object did not work as expected.

### Step to reproduce
```ruby
require 'fiddley'

pt = pt = Fiddley::MemoryPointer.new(:int32, 3)

pt.write_array_of_int32([1, 2, 3])
# => "\x01\x00\x00\x00\x02\x00\x00\x00\x03\x00\x00\x00"

p pt.read_array_of_int32(3)
# => 1
```
I changed `unpack1` to `unpack`. It seems to works.

```ruby
p pt.read_array_of_int32(3)
# => [1, 2, 3]
```