### PR TITLE
Make sure to free pointers

### DIFF
--- a/lib/fiddley/memory_pointer.rb
+++ b/lib/fiddley/memory_pointer.rb
@@ -15,7 +15,7 @@ module Fiddley
         @size = @ptr.size
       else
         @size = type2size(type) * num
-        @ptr = Fiddle::Pointer.malloc(@size)
+        @ptr = Fiddle::Pointer.malloc(@size, RUBY_FREE)
       end
     end
 

--- a/lib/fiddley/struct.rb
+++ b/lib/fiddley/struct.rb
@@ -34,7 +34,7 @@ module Fiddley
     end
 
     def initialize
-      @ptr = Fiddle::Pointer.malloc(self.class.size)
+      @ptr = Fiddle::Pointer.malloc(self.class.size, RUBY_FREE)
     end
 
     def [](key)


### PR DESCRIPTION
Ensure that memory is freed when objects are collected by garbage collection. This will prevent memory leaks.

This pull request is to report changes in GR.rb to upstream.
https://github.com/red-data-tools/GR.rb/pull/60

See the official documents below for details.
https://ruby-doc.org/stdlib-3.0.2/libdoc/fiddle/rdoc/Fiddle/Pointer.html

```ruby
# Automatically freeing the pointer when the block is exited - recommended
Fiddle::Pointer.malloc(size, Fiddle::RUBY_FREE) do |pointer|
  ...
end

# Manually freeing but relying on the garbage collector otherwise
pointer = Fiddle::Pointer.malloc(size, Fiddle::RUBY_FREE)
...
pointer.call_free

# Relying on the garbage collector - may lead to unlimited memory allocated before freeing any, but safe
pointer = Fiddle::Pointer.malloc(size, Fiddle::RUBY_FREE)
...

# Only manually freeing
pointer = Fiddle::Pointer.malloc(size)
begin
  ...
ensure
  Fiddle.free pointer
end

# No free function and no call to free - the native memory will leak if the pointer is garbage collected
pointer = Fiddle::Pointer.malloc(size)
...
```
